### PR TITLE
Basic event store with save()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ authors = ["James Waples <jamwaffles@gmail.com>"]
 travis-ci = { repository = "jamwaffles/event-store-rs", branch = "master" }
 
 [dependencies]
+postgres = { version = "0.15.2", optional = true }
+
+[features]
+default = [ "postgres_support" ]
+postgres_support = [ "postgres" ]

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,4 @@
+/// Base event trait
+///
+/// All events passed to the event store must implement this trait
+pub trait Event {}

--- a/src/eventstore/mod.rs
+++ b/src/eventstore/mod.rs
@@ -1,0 +1,15 @@
+mod postgres;
+
+use event::Event;
+
+pub use self::postgres::PostgresEventStore;
+
+/// Event store trait
+///
+/// All event stores must implement this trait
+pub trait EventStore {
+    /// Save an event to the store
+    fn save<E>(&mut self, event: &E) -> Result<(), String>
+    where
+        E: Event;
+}

--- a/src/eventstore/postgres.rs
+++ b/src/eventstore/postgres.rs
@@ -1,0 +1,14 @@
+use event::Event;
+use eventstore::EventStore;
+
+/// Postgres-backed implementation of an event store
+pub struct PostgresEventStore;
+
+impl EventStore for PostgresEventStore {
+    fn save<E>(&mut self, _event: &E) -> Result<(), String>
+    where
+        E: Event,
+    {
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,26 @@
+//! Event store module for event-driven applications
+
+#![deny(missing_docs)]
+
+mod event;
+mod eventstore;
+
+pub use event::Event;
+pub use eventstore::{EventStore, PostgresEventStore};
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    struct TestEvent {}
+
+    impl Event for TestEvent {}
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn it_has_a_postgres_store() {
+        let mut store = PostgresEventStore {};
+        let e = TestEvent {};
+
+        assert_eq!(store.save(&e), Ok(()));
     }
 }


### PR DESCRIPTION
Base structure an impl of event store.

I've added a `postgres_support` `[feature]` to `Cargo.toml`. It's enabled by default, but will allow us to enable/disable support for whichever various backends we add in the future for best portability.

Closes #9 
Ref #1 