### PR TITLE
Event store using generics and associated types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+postgres_data

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 postgres_data
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ rust:
   - nightly
 sudo: required
 
+services:
+  - docker
+
 before_install:
+  - docker-compose up -d postgres
   - rustup toolchain add nightly || true
   - rustup self update
   - rustup component add rustfmt-preview --toolchain nightly
+  - docker-compose run integration_setup
   - cargo +nightly fmt --version || true
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ travis-ci = { repository = "jamwaffles/event-store-rs", branch = "master" }
 serde = "1.0.71"
 serde_derive = "1.0.71"
 serde_json = "1.0.26"
-postgres = { version = "0.15.2", features = [ "with-serde_json", "with-uuid" ] }
+postgres = { version = "0.15.2", features = [ "with-serde_json", "with-uuid", "with-chrono" ] }
 fallible-iterator = "0.1.5"
 sha2 = "0.7.1"
 chrono = { version = "0.4.5", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ serde = "1.0.71"
 serde_derive = "1.0.71"
 serde_json = "1.0.26"
 postgres = { version = "0.15.2", features = [ "with-serde_json" ] }
+fallible-iterator = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ travis-ci = { repository = "jamwaffles/event-store-rs", branch = "master" }
 serde = "1.0.71"
 serde_derive = "1.0.71"
 serde_json = "1.0.26"
-postgres = { version = "0.15.2", features = [ "with-serde_json" ] }
+postgres = { version = "0.15.2", features = [ "with-serde_json", "with-uuid" ] }
 fallible-iterator = "0.1.5"
 sha2 = "0.7.1"
+chrono = { version = "0.4.5", features = ["serde"] }
+uuid = { version = "0.5.1", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["James Waples <jamwaffles@gmail.com>"]
 travis-ci = { repository = "jamwaffles/event-store-rs", branch = "master" }
 
 [dependencies]
+serde = "1.0.71"
+serde_derive = "1.0.71"
+serde_json = "1.0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde_derive = "1.0.71"
 serde_json = "1.0.26"
 postgres = { version = "0.15.2", features = [ "with-serde_json" ] }
 fallible-iterator = "0.1.5"
+sha2 = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ travis-ci = { repository = "jamwaffles/event-store-rs", branch = "master" }
 serde = "1.0.71"
 serde_derive = "1.0.71"
 serde_json = "1.0.26"
+postgres = { version = "0.15.2", features = [ "with-serde_json" ] }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 [![Build Status](https://travis-ci.org/jamwaffles/event-store-rs.svg?branch=master)](https://travis-ci.org/jamwaffles/event-store-rs)
 
 Event store, but in Rust
+
+## Documentation
+
+```bash
+cargo doc --open
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:10.5-alpine
+    ports:
+      - "5430:5432"
+    volumes:
+      - "./postgres_data:/var/lib/postgresql/data"
+    environment:
+      POSTGRES_USER: eventstore
+      POSTGRES_DB: eventstorerust
+
+  integration_setup:
+    image: postgres:10.5-alpine
+    command: psql -h postgres -U postgres -d eventstorerust -f /opt/integration-tests.sql
+    volumes:
+      - ".:/opt"
+    depends_on:
+      - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - "./postgres_data:/var/lib/postgresql/data"
     environment:
-      POSTGRES_USER: eventstore
+      POSTGRES_USER: postgres
       POSTGRES_DB: eventstorerust
 
   integration_setup:

--- a/integration-tests.sql
+++ b/integration-tests.sql
@@ -1,0 +1,22 @@
+CREATE DATABASE eventstorerust;
+
+\c eventstorerust
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+DROP TABLE events;
+
+CREATE TABLE events (
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    data jsonb NOT NULL,
+    context jsonb DEFAULT '{}'::jsonb
+);
+
+INSERT INTO "events"("data","context")
+VALUES
+(E'{"type": "eventstore.Increment", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T00:00:00+00"}'),
+(E'{"type": "eventstore.Decrement", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T01:00:00+00"}'),
+(E'{"type": "eventstore.Increment", "test_field": "inc_dec", "by": 2}',E'{"time": "2018-03-02T02:00:00+00"}'),
+(E'{"type": "eventstore.Other", "test_field": "other", "foo": "bar"}',E'{"time": "2018-03-02T04:00:00+00"}'),
+(E'{"type": "eventstore.Unknown"}',E'{"time": "2018-03-02T05:00:00+00"}')
+;

--- a/integration-tests.sql
+++ b/integration-tests.sql
@@ -14,9 +14,9 @@ CREATE TABLE events (
 
 INSERT INTO "events"("data","context")
 VALUES
-(E'{"type": "eventstore.Increment", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T00:00:00+00"}'),
-(E'{"type": "eventstore.Decrement", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T01:00:00+00"}'),
-(E'{"type": "eventstore.Increment", "test_field": "inc_dec", "by": 2}',E'{"time": "2018-03-02T02:00:00+00"}'),
-(E'{"type": "eventstore.Other", "test_field": "other", "foo": "bar"}',E'{"time": "2018-03-02T04:00:00+00"}'),
-(E'{"type": "eventstore.Unknown"}',E'{"time": "2018-03-02T05:00:00+00"}')
+(E'{"type": "some_namespace.Inc", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T00:00:00+00"}'),
+(E'{"type": "some_namespace.Dec", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T01:00:00+00"}'),
+(E'{"type": "some_namespace.Inc", "test_field": "inc_dec", "by": 2}',E'{"time": "2018-03-02T02:00:00+00"}')
+-- (E'{"type": "some_namespace.Other", "test_field": "other", "foo": "bar"}',E'{"time": "2018-03-02T04:00:00+00"}'),
+-- (E'{"type": "some_namespace.Unknown"}',E'{"time": "2018-03-02T05:00:00+00"}')
 ;

--- a/integration-tests.sql
+++ b/integration-tests.sql
@@ -23,10 +23,10 @@ CREATE TABLE aggregate_cache (
 
 INSERT INTO "events"("data","context")
 VALUES
-(E'{"type": "some_namespace.Inc", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T00:00:00+00"}'),
-(E'{"type": "some_namespace.Dec", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T01:00:00+00"}'),
-(E'{"type": "some_namespace.Inc", "test_field": "inc_dec", "by": 2}',E'{"time": "2018-03-02T02:00:00+00"}')
--- (E'{"type": "some_namespace.Other", "test_field": "other", "foo": "bar"}',E'{"time": "2018-03-02T04:00:00+00"}'),
+(E'{"type": "some_namespace.Inc", "ident": "inc_dec", "by": 1}',E'{"time": "2018-03-02T00:00:00+00"}'),
+(E'{"type": "some_namespace.Dec", "ident": "inc_dec", "by": 1}',E'{"time": "2018-03-02T01:00:00+00"}'),
+(E'{"type": "some_namespace.Inc", "ident": "inc_dec", "by": 2}',E'{"time": "2018-03-02T02:00:00+00"}')
+-- (E'{"type": "some_namespace.Other", "ident": "other", "foo": "bar"}',E'{"time": "2018-03-02T04:00:00+00"}'),
 -- (E'{"type": "some_namespace.Unknown"}',E'{"time": "2018-03-02T05:00:00+00"}')
 ;
 

--- a/integration-tests.sql
+++ b/integration-tests.sql
@@ -12,6 +12,15 @@ CREATE TABLE events (
     context jsonb DEFAULT '{}'::jsonb
 );
 
+DROP TABLE aggregate_cache;
+
+CREATE TABLE aggregate_cache (
+    id bytea PRIMARY KEY,
+    -- id character varying(64) PRIMARY KEY,
+    data jsonb NOT NULL,
+    time timestamp without time zone DEFAULT now()
+);
+
 INSERT INTO "events"("data","context")
 VALUES
 (E'{"type": "some_namespace.Inc", "test_field": "inc_dec", "by": 1}',E'{"time": "2018-03-02T00:00:00+00"}'),
@@ -20,3 +29,5 @@ VALUES
 -- (E'{"type": "some_namespace.Other", "test_field": "other", "foo": "bar"}',E'{"time": "2018-03-02T04:00:00+00"}'),
 -- (E'{"type": "some_namespace.Unknown"}',E'{"time": "2018-03-02T05:00:00+00"}')
 ;
+
+INSERT INTO "aggregate_cache"(id, data, time) VALUES (E'\\xDEADBEEF', E'{ "hello": "world" }', NOW());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,11 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 // --- Event store crate ---
-trait Event {}
-trait Events {}
-trait StoreQuery {}
-struct PgQuery(String);
-trait Aggregator<E: Events, A, Q: StoreQuery>: Copy + Clone + Debug + Default {
+pub trait Event {}
+pub trait Events {}
+pub trait StoreQuery {}
+pub struct PgQuery(pub String);
+pub trait Aggregator<E: Events, A, Q: StoreQuery>: Copy + Clone + Debug + Default {
     fn apply_event(acc: Self, event: &E) -> Self;
 
     fn query() -> Q;
@@ -21,21 +21,29 @@ trait Aggregator<E: Events, A, Q: StoreQuery>: Copy + Clone + Debug + Default {
 
 impl StoreQuery for PgQuery {}
 
-trait Store<E: Events> {
+pub trait Store<E: Events> {
+    fn new() -> Self;
+
     fn aggregate<T, A, Q: StoreQuery>(&self, query: A) -> T
     where
         E: Events,
         T: Aggregator<E, A, Q>;
 }
 
-struct FakeBackedStore<E: Events> {
+pub struct PgStore<E: Events> {
     phantom: PhantomData<E>,
 }
 
-impl<'a, E> Store<E> for FakeBackedStore<E>
+impl<'a, E> Store<E> for PgStore<E>
 where
     E: Events + Deserialize<'a>,
 {
+    fn new() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+
     fn aggregate<T, A, Q: StoreQuery>(&self, _query: A) -> T
     where
         T: Aggregator<E, A, Q>,
@@ -60,85 +68,5 @@ where
             .fold(T::default(), |acc, event| T::apply_event(acc, event));
 
         result
-    }
-}
-
-// --- Example implementation for the Toaster domain ---
-#[derive(Deserialize)]
-struct Increment {
-    pub by: i32,
-}
-#[derive(Deserialize)]
-struct Decrement {
-    pub by: i32,
-}
-
-impl Event for Increment {}
-impl Event for Decrement {}
-
-#[derive(Deserialize)]
-#[serde(tag = "type")]
-enum ToasterEvents {
-    Inc(Increment),
-    Dec(Decrement),
-}
-
-impl Events for ToasterEvents {}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-struct SomeDomainEntity {
-    counter: i32,
-}
-
-impl Default for SomeDomainEntity {
-    fn default() -> Self {
-        Self { counter: 0 }
-    }
-}
-
-impl Aggregator<ToasterEvents, (String, String), PgQuery> for SomeDomainEntity {
-    fn apply_event(acc: Self, event: &ToasterEvents) -> Self {
-        let counter = match event {
-            ToasterEvents::Inc(inc) => acc.counter + inc.by,
-            ToasterEvents::Dec(dec) => acc.counter - dec.by,
-        };
-
-        Self { counter, ..acc }
-    }
-
-    fn query() -> PgQuery {
-        PgQuery(String::from("SELECT * FROM events WHERE toast = 'yes'"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_aggregates_events() {
-        let events = vec![
-            ToasterEvents::Inc(Increment { by: 1 }),
-            ToasterEvents::Inc(Increment { by: 1 }),
-            ToasterEvents::Dec(Decrement { by: 2 }),
-            ToasterEvents::Inc(Increment { by: 2 }),
-            ToasterEvents::Dec(Decrement { by: 3 }),
-            ToasterEvents::Dec(Decrement { by: 3 }),
-        ];
-
-        let result: SomeDomainEntity = events
-            .iter()
-            .fold(SomeDomainEntity::default(), SomeDomainEntity::apply_event);
-
-        assert_eq!(result, SomeDomainEntity { counter: -4 });
-    }
-
-    #[test]
-    fn thing() {
-        let store = FakeBackedStore::<ToasterEvents> {
-            phantom: PhantomData,
-        };
-
-        let _entity: SomeDomainEntity = store.aggregate(("id".into(), "oenebtio".into()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,13 @@ where
     {
         let inc: E = serde_json::from_str(
             r#"{
-            "type": "Inc",
+            "type": "some_namespace.Inc",
             "by": 1
         }"#,
         ).unwrap();
         let dec: E = serde_json::from_str(
             r#"{
-            "type": "Dec",
+            "type": "some_namespace.Dec",
             "by": 1
         }"#,
         ).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,13 @@ extern crate postgres;
 extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
+extern crate sha2;
 
 pub mod pg;
 pub mod testhelpers;
 
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 
 /// Trait to be implemented by all domain events
@@ -70,7 +73,7 @@ pub trait StoreQuery {}
 ///     }
 /// }
 /// ```
-pub trait Aggregator<E: Events, A, Q: StoreQuery>: Copy + Clone + Debug + Default {
+pub trait Aggregator<E: Events, A: Clone, Q: StoreQuery>: Copy + Clone + Debug + Default {
     /// Apply an event `E` to `acc`, returning a copy of `Self` with updated fields. Can also just
     /// return `acc` if nothing has changed.
     fn apply_event(acc: Self, event: &E) -> Self;
@@ -98,5 +101,6 @@ pub trait Store<E: Events, Q: StoreQuery> {
     fn aggregate<T, A>(&self, query: A) -> T
     where
         E: Events,
-        T: Aggregator<E, A, Q>;
+        A: Clone,
+        T: Aggregator<E, A, Q> + Serialize + DeserializeOwned;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
 extern crate fallible_iterator;
 extern crate postgres;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
+
+pub mod testhelpers;
 
 use fallible_iterator::FallibleIterator;
 use postgres::types::ToSql;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,34 @@
+#[macro_use]
+extern crate serde_derive;
+
+extern crate serde;
+extern crate serde_json;
+
+use serde::Deserialize;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 // --- Event store crate ---
 trait Event {}
 trait Events {}
-trait Aggregate<E: Events>: Copy + Clone + Debug + Default {
-    fn apply_event(self, event: &E) -> Self;
+trait Aggregator<E: Events, Q>: Copy + Clone + Debug + Default {
+    fn apply_event(acc: Self, event: &E) -> Self;
 }
 
 // --- Example implementation for the Toaster domain ---
-struct Increment(pub i32);
-struct Decrement(pub i32);
+#[derive(Deserialize)]
+struct Increment {
+    pub by: i32,
+}
+#[derive(Deserialize)]
+struct Decrement {
+    pub by: i32,
+}
 
 impl Event for Increment {}
 impl Event for Decrement {}
 
+#[derive(Deserialize)]
 enum ToasterEvents {
     Inc(Increment),
     Dec(Decrement),
@@ -32,14 +47,57 @@ impl Default for SomeDomainEntity {
     }
 }
 
-impl Aggregate<ToasterEvents> for SomeDomainEntity {
-    fn apply_event(self, event: &ToasterEvents) -> Self {
+impl Aggregator<ToasterEvents, (String, String)> for SomeDomainEntity {
+    fn apply_event(acc: Self, event: &ToasterEvents) -> Self {
         let counter = match event {
-            ToasterEvents::Inc(inc) => self.counter + inc.0,
-            ToasterEvents::Dec(dec) => self.counter - dec.0,
+            ToasterEvents::Inc(inc) => acc.counter + inc.by,
+            ToasterEvents::Dec(dec) => acc.counter - dec.by,
         };
 
-        Self { counter, ..self }
+        Self { counter, ..acc }
+    }
+    // fn query() -> String // select * from events where id = $1 and name = $2
+}
+
+trait Store<E: Events> {
+    fn aggregate<T, A>(&self, query: A) -> T
+    where
+        E: Events,
+        T: Aggregator<E, A>;
+}
+
+struct FakeBackedStore<E: Events> {
+    phantom: PhantomData<E>,
+}
+
+impl<'a, E> Store<E> for FakeBackedStore<E>
+where
+    E: Events + Deserialize<'a>,
+{
+    fn aggregate<T, A>(&self, _query: A) -> T
+    where
+        T: Aggregator<E, A>,
+    {
+        let inc: E = serde_json::from_str(
+            r#"{
+            "type": "Inc",
+            "by": 1
+        }"#,
+        ).unwrap();
+        let dec: E = serde_json::from_str(
+            r#"{
+            "type": "Dec",
+            "by": 1
+        }"#,
+        ).unwrap();
+
+        let events = vec![inc, dec];
+
+        let result = events
+            .iter()
+            .fold(T::default(), |acc, event| T::apply_event(acc, event));
+
+        result
     }
 }
 
@@ -50,20 +108,27 @@ mod tests {
     #[test]
     fn it_aggregates_events() {
         let events = vec![
-            ToasterEvents::Inc(Increment(1)),
-            ToasterEvents::Inc(Increment(1)),
-            ToasterEvents::Dec(Decrement(2)),
-            ToasterEvents::Inc(Increment(2)),
-            ToasterEvents::Dec(Decrement(3)),
-            ToasterEvents::Dec(Decrement(3)),
+            ToasterEvents::Inc(Increment { by: 1 }),
+            ToasterEvents::Inc(Increment { by: 1 }),
+            ToasterEvents::Dec(Decrement { by: 2 }),
+            ToasterEvents::Inc(Increment { by: 2 }),
+            ToasterEvents::Dec(Decrement { by: 3 }),
+            ToasterEvents::Dec(Decrement { by: 3 }),
         ];
 
         let result: SomeDomainEntity = events
             .iter()
-            .fold(SomeDomainEntity::default(), |acc, event| {
-                acc.apply_event(event)
-            });
+            .fold(SomeDomainEntity::default(), SomeDomainEntity::apply_event);
 
         assert_eq!(result, SomeDomainEntity { counter: -4 });
+    }
+
+    #[test]
+    fn thing() {
+        let store = FakeBackedStore::<ToasterEvents> {
+            phantom: PhantomData,
+        };
+
+        let _entity: SomeDomainEntity = store.aggregate(("id".into(), "oenebtio".into()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,69 @@
+use std::fmt::Debug;
+
+// --- Event store crate ---
+trait Event {}
+trait Events {}
+trait Aggregate<E: Events>: Copy + Clone + Debug + Default {
+    fn apply_event(self, event: &E) -> Self;
+}
+
+// --- Example implementation for the Toaster domain ---
+struct Increment(pub i32);
+struct Decrement(pub i32);
+
+impl Event for Increment {}
+impl Event for Decrement {}
+
+enum ToasterEvents {
+    Inc(Increment),
+    Dec(Decrement),
+}
+
+impl Events for ToasterEvents {}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+struct SomeDomainEntity {
+    counter: i32,
+}
+
+impl Default for SomeDomainEntity {
+    fn default() -> Self {
+        Self { counter: 0 }
+    }
+}
+
+impl Aggregate<ToasterEvents> for SomeDomainEntity {
+    fn apply_event(self, event: &ToasterEvents) -> Self {
+        let counter = match event {
+            ToasterEvents::Inc(inc) => self.counter + inc.0,
+            ToasterEvents::Dec(dec) => self.counter - dec.0,
+        };
+
+        Self { counter, ..self }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn it_aggregates_events() {
+        let events = vec![
+            ToasterEvents::Inc(Increment(1)),
+            ToasterEvents::Inc(Increment(1)),
+            ToasterEvents::Dec(Decrement(2)),
+            ToasterEvents::Inc(Increment(2)),
+            ToasterEvents::Dec(Decrement(3)),
+            ToasterEvents::Dec(Decrement(3)),
+        ];
+
+        let result: SomeDomainEntity = events
+            .iter()
+            .fold(SomeDomainEntity::default(), |acc, event| {
+                acc.apply_event(event)
+            });
+
+        assert_eq!(result, SomeDomainEntity { counter: -4 });
     }
 }

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -6,7 +6,9 @@ use postgres::types::ToSql;
 use postgres::Connection;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use serde_json::{from_value, Value as JsonValue};
+use serde::Serialize;
+use serde_json::{from_value, to_value, Value as JsonValue};
+use sha2::{Digest, Sha256};
 use std::marker::PhantomData;
 
 /// Representation of a Postgres query and args
@@ -44,17 +46,64 @@ where
             conn,
         }
     }
+
+    fn cache_save<T>(&self, q: &PgQuery, result: &T)
+    where
+        T: Serialize,
+    {
+        let args_hash = Sha256::digest(format!("{:?}:[{}]", q.args, q.query).as_bytes());
+
+        self.conn
+            .execute(
+                r#"INSERT INTO aggregate_cache (id, data, time)
+                VALUES ($1, $2, NOW())
+                ON CONFLICT (id)
+                DO UPDATE SET data = EXCLUDED.data, time = now() RETURNING data"#,
+                &[&args_hash.as_slice(), &to_value(result).expect("To value")],
+            ).expect("Cache");
+    }
+
+    fn cache_find<T>(&self, q: &PgQuery) -> Option<T>
+    where
+        T: DeserializeOwned + Default,
+    {
+        let args_hash = Sha256::digest(format!("{:?}:[{}]", q.args, q.query).as_bytes());
+
+        let rows = self
+            .conn
+            .query(
+                "SELECT data FROM aggregate_cache WHERE id = $1 LIMIT 1",
+                &[&args_hash.as_slice()],
+            ).expect("Ret");
+
+        // `rows.get()` panics if index is out of bounds, hence this check. Should be an Option.
+        if rows.len() != 1 {
+            None
+        } else {
+            from_value(rows.get(0).get(0))
+                .map(|decoded: T| decoded)
+                .ok()
+        }
+    }
 }
 
 impl<'a, E> Store<E, PgQuery<'a>> for PgStore<E>
 where
-    E: Events + DeserializeOwned,
+    E: Events + DeserializeOwned + Serialize,
 {
     fn aggregate<T, A>(&self, query_args: A) -> T
     where
-        T: Aggregator<E, A, PgQuery<'a>>,
+        T: Aggregator<E, A, PgQuery<'a>> + Serialize + DeserializeOwned,
+        A: Clone,
     {
-        let PgQuery { query, args } = T::query(query_args);
+        let cached: Option<T> = self.cache_find(&T::query(query_args.clone()));
+
+        if let Some(c) = cached {
+            println!("GOT CACHED {:?}", cached);
+            return c;
+        }
+
+        let PgQuery { query, args } = T::query(query_args.clone());
 
         let mut params: Vec<&ToSql> = Vec::new();
 
@@ -75,6 +124,10 @@ where
                 evt
             }).fold(T::default(), |acc, event| T::apply_event(acc, &event))
             .expect("Fold");
+
+        trans.finish().expect("Tranny finished");
+
+        self.cache_save(&T::query(query_args.clone()), &results);
 
         results
     }

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -1,0 +1,81 @@
+//! Postgres-backed event store
+
+use super::{Aggregator, Events, Store, StoreQuery};
+use fallible_iterator::FallibleIterator;
+use postgres::types::ToSql;
+use postgres::Connection;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::{from_value, Value as JsonValue};
+use std::marker::PhantomData;
+
+/// Representation of a Postgres query and args
+pub struct PgQuery<'a> {
+    /// Query string with placeholders
+    query: &'a str,
+
+    /// Arguments to use for the query
+    args: Vec<Box<ToSql>>,
+}
+
+impl<'a> StoreQuery for PgQuery<'a> {}
+
+impl<'a> PgQuery<'a> {
+    /// Create a new query from a query string and arguments
+    pub fn new(query: &'a str, args: Vec<Box<ToSql>>) -> Self {
+        Self { query, args }
+    }
+}
+
+/// Postgres-backed event store
+pub struct PgStore<E: Events> {
+    phantom: PhantomData<E>,
+    conn: Connection,
+}
+
+impl<'a, E> PgStore<E>
+where
+    E: Events + Deserialize<'a>,
+{
+    /// Create a new PgStore from a Postgres DB connection
+    pub fn new(conn: Connection) -> Self {
+        Self {
+            phantom: PhantomData,
+            conn,
+        }
+    }
+}
+
+impl<'a, E> Store<E, PgQuery<'a>> for PgStore<E>
+where
+    E: Events + DeserializeOwned,
+{
+    fn aggregate<T, A>(&self, query_args: A) -> T
+    where
+        T: Aggregator<E, A, PgQuery<'a>>,
+    {
+        let PgQuery { query, args } = T::query(query_args);
+
+        let mut params: Vec<&ToSql> = Vec::new();
+
+        for (i, _arg) in args.iter().enumerate() {
+            params.push(&*args[i]);
+        }
+
+        let trans = self.conn.transaction().expect("Tranny");
+        let stmt = trans.prepare(&query).expect("Prep");
+
+        let results = stmt
+            .lazy_query(&trans, &params, 1000)
+            .expect("Query")
+            .map(|row| {
+                let json: JsonValue = row.get("data");
+                let evt: E = from_value(json).expect("Decode");
+
+                evt
+            }).fold(T::default(), |acc, event| T::apply_event(acc, &event))
+            .expect("Fold");
+
+        results
+    }
+}

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -85,13 +85,7 @@ where
         } else {
             let row = rows.get(0);
 
-            // let r: DateTime<Local> = row.get(1);
-
-            // println!("COL 1 {:?}", r);
-
             let time: NaiveDateTime = row.get(1);
-
-            // let time: NaiveDateTime = Utc::now();
 
             Some((
                 from_value(row.get(0)).map(|decoded: T| decoded).unwrap(),

--- a/src/testhelpers.rs
+++ b/src/testhelpers.rs
@@ -1,12 +1,19 @@
-use super::{Aggregator, Event, Events, PgQuery};
+//! Test helpers. Do not use in application code.
+
+use super::{Aggregator, Event, Events};
+use pg::PgQuery;
 use postgres::types::ToSql;
 
 #[derive(Deserialize)]
+/// Test event
 pub struct TestIncrementEvent {
+    /// Increment by this much
     pub by: i32,
 }
 #[derive(Deserialize)]
+/// Test event
 pub struct TestDecrementEvent {
+    /// Decrement by this much
     pub by: i32,
 }
 
@@ -15,11 +22,15 @@ impl Event for TestDecrementEvent {}
 
 #[derive(Deserialize)]
 #[serde(tag = "type")]
+/// Set of all events in the domain
 pub enum TestEvents {
+    /// Increment
     #[serde(rename = "some_namespace.Inc")]
     Inc(TestIncrementEvent),
+    /// Decrement
     #[serde(rename = "some_namespace.Dec")]
     Dec(TestDecrementEvent),
+    /// Some other event
     #[serde(rename = "some_namespace.Other")]
     Other,
 }
@@ -27,7 +38,9 @@ pub enum TestEvents {
 impl Events for TestEvents {}
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+/// Testing entity for a pretend domain
 pub struct TestCounterEntity {
+    /// Current counter value
     pub counter: i32,
 }
 

--- a/src/testhelpers.rs
+++ b/src/testhelpers.rs
@@ -4,13 +4,13 @@ use super::{Aggregator, Event, Events};
 use pg::PgQuery;
 use postgres::types::ToSql;
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 /// Test event
 pub struct TestIncrementEvent {
     /// Increment by this much
     pub by: i32,
 }
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 /// Test event
 pub struct TestDecrementEvent {
     /// Decrement by this much
@@ -20,7 +20,7 @@ pub struct TestDecrementEvent {
 impl Event for TestIncrementEvent {}
 impl Event for TestDecrementEvent {}
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
 /// Set of all events in the domain
 pub enum TestEvents {
@@ -37,7 +37,7 @@ pub enum TestEvents {
 
 impl Events for TestEvents {}
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq)]
 /// Testing entity for a pretend domain
 pub struct TestCounterEntity {
     /// Current counter value

--- a/src/testhelpers.rs
+++ b/src/testhelpers.rs
@@ -1,0 +1,61 @@
+use super::{Aggregator, Event, Events, PgQuery};
+use postgres::types::ToSql;
+
+#[derive(Deserialize)]
+pub struct TestIncrementEvent {
+    pub by: i32,
+}
+#[derive(Deserialize)]
+pub struct TestDecrementEvent {
+    pub by: i32,
+}
+
+impl Event for TestIncrementEvent {}
+impl Event for TestDecrementEvent {}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+pub enum TestEvents {
+    #[serde(rename = "some_namespace.Inc")]
+    Inc(TestIncrementEvent),
+    #[serde(rename = "some_namespace.Dec")]
+    Dec(TestDecrementEvent),
+    #[serde(rename = "some_namespace.Other")]
+    Other,
+}
+
+impl Events for TestEvents {}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct TestCounterEntity {
+    pub counter: i32,
+}
+
+impl Default for TestCounterEntity {
+    fn default() -> Self {
+        Self { counter: 0 }
+    }
+}
+
+impl<'a> Aggregator<TestEvents, String, PgQuery<'a>> for TestCounterEntity {
+    fn apply_event(acc: Self, event: &TestEvents) -> Self {
+        let counter = match event {
+            TestEvents::Inc(inc) => acc.counter + inc.by,
+            TestEvents::Dec(dec) => acc.counter - dec.by,
+            _ => acc.counter,
+        };
+
+        Self { counter, ..acc }
+    }
+
+    fn query(field: String) -> PgQuery<'a> {
+        let mut params: Vec<Box<ToSql>> = Vec::new();
+
+        params.push(Box::new(field));
+
+        PgQuery::new(
+            "select * from events where data->>'test_field' = $1",
+            params,
+        )
+    }
+}

--- a/src/testhelpers.rs
+++ b/src/testhelpers.rs
@@ -9,12 +9,18 @@ use postgres::types::ToSql;
 pub struct TestIncrementEvent {
     /// Increment by this much
     pub by: i32,
+
+    /// Test identifier
+    pub ident: String,
 }
 #[derive(Serialize, Deserialize)]
 /// Test event
 pub struct TestDecrementEvent {
     /// Decrement by this much
     pub by: i32,
+
+    /// Test identifier
+    pub ident: String,
 }
 
 impl Event for TestIncrementEvent {}
@@ -66,9 +72,6 @@ impl<'a> Aggregator<TestEvents, String, PgQuery<'a>> for TestCounterEntity {
 
         params.push(Box::new(field));
 
-        PgQuery::new(
-            "select * from events where data->>'test_field' = $1",
-            params,
-        )
+        PgQuery::new("select * from events where data->>'ident' = $1", params)
     }
 }

--- a/tests/pg.rs
+++ b/tests/pg.rs
@@ -4,7 +4,7 @@ extern crate postgres;
 use event_store_rs::testhelpers::{
     TestCounterEntity, TestDecrementEvent, TestEvents, TestIncrementEvent,
 };
-use event_store_rs::{Aggregator, PgStore, Store};
+use event_store_rs::{pg::PgStore, Aggregator, Store};
 use postgres::{Connection, TlsMode};
 
 #[test]

--- a/tests/pg.rs
+++ b/tests/pg.rs
@@ -21,7 +21,9 @@ impl Event for Decrement {}
 #[derive(Deserialize)]
 #[serde(tag = "type")]
 enum ToasterEvents {
+    #[serde(rename = "some_namespace.Inc")]
     Inc(Increment),
+    #[serde(rename = "some_namespace.Dec")]
     Dec(Decrement),
 }
 

--- a/tests/pg.rs
+++ b/tests/pg.rs
@@ -36,3 +36,17 @@ fn it_queries_the_database() {
 
     let _entity: TestCounterEntity = store.aggregate("inc_dec".into());
 }
+
+#[test]
+fn it_saves_events() {
+    let conn = Connection::connect(
+        "postgres://postgres@localhost:5430/eventstorerust",
+        TlsMode::None,
+    ).expect("Could not connect to DB");
+
+    let store = PgStore::<TestEvents>::new(conn);
+
+    let event = TestEvents::Inc(TestIncrementEvent { by: 123123 });
+
+    assert!(store.save(event, None::<()>).is_ok());
+}

--- a/tests/pg.rs
+++ b/tests/pg.rs
@@ -1,0 +1,85 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate event_store_rs;
+extern crate serde;
+extern crate serde_json;
+
+use event_store_rs::{Aggregator, Event, Events, PgQuery, PgStore};
+
+#[derive(Deserialize)]
+struct Increment {
+    pub by: i32,
+}
+#[derive(Deserialize)]
+struct Decrement {
+    pub by: i32,
+}
+
+impl Event for Increment {}
+impl Event for Decrement {}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum ToasterEvents {
+    Inc(Increment),
+    Dec(Decrement),
+}
+
+impl Events for ToasterEvents {}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+struct SomeDomainEntity {
+    counter: i32,
+}
+
+impl Default for SomeDomainEntity {
+    fn default() -> Self {
+        Self { counter: 0 }
+    }
+}
+
+impl Aggregator<ToasterEvents, (String, String), PgQuery> for SomeDomainEntity {
+    fn apply_event(acc: Self, event: &ToasterEvents) -> Self {
+        let counter = match event {
+            ToasterEvents::Inc(inc) => acc.counter + inc.by,
+            ToasterEvents::Dec(dec) => acc.counter - dec.by,
+        };
+
+        Self { counter, ..acc }
+    }
+
+    fn query() -> PgQuery {
+        PgQuery(String::from("SELECT * FROM events WHERE toast = 'yes'"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use event_store_rs::Store;
+
+    #[test]
+    fn it_aggregates_events() {
+        let events = vec![
+            ToasterEvents::Inc(Increment { by: 1 }),
+            ToasterEvents::Inc(Increment { by: 1 }),
+            ToasterEvents::Dec(Decrement { by: 2 }),
+            ToasterEvents::Inc(Increment { by: 2 }),
+            ToasterEvents::Dec(Decrement { by: 3 }),
+            ToasterEvents::Dec(Decrement { by: 3 }),
+        ];
+
+        let result: SomeDomainEntity = events
+            .iter()
+            .fold(SomeDomainEntity::default(), SomeDomainEntity::apply_event);
+
+        assert_eq!(result, SomeDomainEntity { counter: -4 });
+    }
+
+    #[test]
+    fn thing() {
+        let store = PgStore::new();
+
+        let _entity: SomeDomainEntity = store.aggregate(("id".into(), "oenebtio".into()));
+    }
+}

--- a/tests/pg.rs
+++ b/tests/pg.rs
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    fn thing() {
+    fn it_queries_the_database() {
         let conn = Connection::connect(
             "postgres://postgres@localhost:5430/eventstorerust",
             TlsMode::None,


### PR DESCRIPTION
Once the supporting code is implemented, aggregating events into an entity is as simple as:

```rust
let _entity: MyDomainEntity = store.aggregate(String::from("some_query_arg"));
```

Closes #14 as this is a far better impl.

### TODO

* [ ] ~R2D2 pool support~ later
* [x] `store.save()`
* [x] Aggregate caching
* [x] Only query for new events since last aggregate
* [ ] ~Make a fake store so tests don't have to talk to DB~ later, let's get this PR moving

Closes #1 
Closes #6 
Closes #7 
Closes #9 
Closes #10 